### PR TITLE
Reset password with token front

### DIFF
--- a/assets/css/resetPasswordWithToken.scss
+++ b/assets/css/resetPasswordWithToken.scss
@@ -1,0 +1,56 @@
+@import "~bootstrap/scss/bootstrap";
+
+html, body {
+  height: 100%;
+  margin: 0;
+}
+
+body {
+  background-color: #3ca2a8;
+}
+
+.main-content {
+  min-height: 90vh;
+  margin: 0;
+}
+
+#reset-password-text {
+  margin-top: 7%;
+  float: none;
+  width: 99%;
+  text-align: center;
+  font-size: 20px;
+  font-weight: bold;
+}
+
+.wrap {
+  display: flex;
+  flex-wrap: wrap;
+}
+
+#wrapper {
+  min-height: 190px;
+  min-width: 250px;
+  background-color: #dfdfdf;
+  border-radius: 25px;
+  border: 1px #bbbbbb;
+  margin-top: 5%;
+}
+
+.form-content {
+  margin-left: 12%;
+  margin-top: 11%;
+}
+
+#new_password_after_resetting_password_first,
+#new_password_after_resetting_password_second {
+  border-radius: 5px;
+  height: 30px;
+}
+
+#new_password_after_resetting_submit {
+  background-color: #222222;
+  color: #dfdfdf;
+  margin-left: 50%;
+  border-radius: 5px;
+}

--- a/src/Form/NewPasswordAfterResettingType.php
+++ b/src/Form/NewPasswordAfterResettingType.php
@@ -17,11 +17,19 @@ class NewPasswordAfterResettingType extends AbstractType
         $builder
             ->add('password', RepeatedType::class, array(
                 'type' => PasswordType::class,
-                'first_options' => array('label' => 'Password'),
-                'second_options' => array('label' => 'Repeat password')
+                'first_options' => array(
+                    'attr' => ['placeholder' => 'Nouveau mot de passe'],
+                    'label' => false,
+                ),
+                'second_options' => array(
+                    'attr' => ['placeholder' => 'Confirmation'],
+                    'label' => false,
+                ),
             ))
             ->add('token', HiddenType::class)
-            ->add('submit', SubmitType::class)
+            ->add('submit', SubmitType::class, array(
+                'label' => 'Valider',
+            ))
         ;
     }
 

--- a/templates/security/new_pwd_after_resetting.html.twig
+++ b/templates/security/new_pwd_after_resetting.html.twig
@@ -1,10 +1,26 @@
 {% extends 'base.html.twig' %}
 
+{% block stylesheets %}
+    {{ encore_entry_link_tags('resetPasswordWithTokenStyle') }}
+{% endblock %}
+
 {% block body %}
-    {{ form_start(form) }}
-    {{ form_row(form.password.first) }}
-    {{ form_row(form.password.second) }}
-    {{ form_row(form.token) }}
-    {{ form_row(form.submit) }}
-    {{ form_end(form) }}
+    <div class="main-content">
+        <div class="h-75">
+            <div class="wrap justify-content-center">
+                <div id="wrapper">
+                    {{ form_start(form) }}
+                        <div class="form-content">
+                            {{ form_row(form.password.first) }}
+                            <br>
+                            {{ form_row(form.password.second) }}
+                            <br>
+                            {{ form_row(form.token) }}
+                            {{ form_row(form.submit) }}
+                        </div>
+                    {{ form_end(form) }}
+                </div>
+            </div>
+        </div>
+    </div>
 {% endblock %}

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -41,6 +41,7 @@ Encore
     .addStyleEntry('loginStyle', './assets/css/login.scss')
     .addStyleEntry('profileStyle', './assets/css/profile.scss')
     .addStyleEntry('resetPasswordStyle', './assets/css/resetPassword.scss')
+    .addStyleEntry('resetPasswordWithTokenStyle', './assets/css/resetPasswordWithToken.scss')
     .addStyleEntry('adIndexStyle', './assets/css/adIndex.scss')
     .addStyleEntry('adShowStyle', './assets/css/adShow.scss')
 


### PR DESCRIPTION
Add resetPasswordWithToken.scss, which manage
CSS for the reset with token page.
Modified NewPasswordAfterRessetingType.php,
to make it's use easier in the twig file.
Modified new_pwd_after_resetting.html.twig,
to get a better display/UI.
Modified webpack.config.js, to be able to use
ressetPasswordwithToken.scss in the twig.